### PR TITLE
Pass Bucket as a string to head_bucket

### DIFF
--- a/contextgraph/bucket.py
+++ b/contextgraph/bucket.py
@@ -30,7 +30,7 @@ class Bucket(object):
         self._resource = s3 = boto3.resource('s3')
         self._bucket = bucket = s3.Bucket(self.name)
         try:
-            s3.meta.client.head_bucket(bucket)
+            s3.meta.client.head_bucket(Bucket=self.name)
         except botocore.exceptions.ClientError:
             raven.captureException()
             return False


### PR DESCRIPTION
When attempting to run contextgraph-service in worker role the following traceback occurs:

```
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: Traceback (most recent call last):
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/usr/local/lib/python3.5/site-packages/billiard/process.py", line 292, in _bootstrap
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: self.run()
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/usr/local/lib/python3.5/site-packages/billiard/pool.py", line 292, in run
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: self.after_fork()
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/usr/local/lib/python3.5/site-packages/billiard/pool.py", line 395, in after_fork
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: self.initializer(*self.initargs)
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/usr/local/lib/python3.5/site-packages/celery/concurrency/prefork.py", line 84, in process_initializer
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: signals.worker_process_init.send(sender=None)
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/usr/local/lib/python3.5/site-packages/celery/utils/dispatch/signal.py", line 166, in send
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: response = receiver(signal=self, sender=sender, **named)
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/app/contextgraph/worker/app.py", line 59, in init_worker_process
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: init_worker(celery_app)
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/app/contextgraph/worker/app.py", line 42, in init_worker
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: celery_app.bucket.connect(celery_app.raven)
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/app/contextgraph/bucket.py", line 33, in connect
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: s3.meta.client.head_bucket(bucket)
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: File "/usr/local/lib/python3.5/site-packages/botocore/client.py", line 256, in _api_call
Jun 03 21:04:19 ip-172-31-36-20 docker[3905]: "%s() only accepts keyword arguments." % py_operation_name)
```

This patch resolves the issue. r?
